### PR TITLE
Bugfix/42 linux to windows image sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,6 +2645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +2979,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,6 +3038,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml",
+ "twox-hash",
  "uuid",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ async-trait = "0.1.82"
 futures = "0.3.30"
 clipboard-rs = "0.2.1"
 console = "0.15.8"
+twox-hash = "1.6.3"
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.4.0" }

--- a/src/clipboard/clipboard.rs
+++ b/src/clipboard/clipboard.rs
@@ -2,10 +2,16 @@ use anyhow::Result;
 use chrono::Utc;
 use clipboard_rs::common::RustImage;
 use clipboard_rs::{Clipboard, ClipboardContext, ClipboardHandler, RustImageData};
+#[cfg(target_os = "windows")]
+use clipboard_win::empty;
+use clipboard_win::{formats, set_clipboard};
 use log::debug;
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
+#[cfg(target_os = "windows")]
+use winapi::um::winuser::{CloseClipboard, OpenClipboard};
 
+use crate::config::CONFIG;
 use crate::message::Payload;
 use crate::config::CONFIG;
 use bytes::Bytes;
@@ -59,6 +65,7 @@ impl RsClipboard {
         Ok(image)
     }
 
+    #[cfg(not(target_os = "windows"))]
     fn write_image(&self, image: RustImageData) -> Result<()> {
         let clipboard = self.clipboard();
         let guard = clipboard
@@ -67,6 +74,18 @@ impl RsClipboard {
         guard
             .set_image(image)
             .map_err(|e| anyhow::anyhow!("Failed to set image: {}", e))
+    }
+
+    #[cfg(target_os = "windows")]
+    fn write_image(&self, image: RustImageData) -> Result<()> {
+        Self::ensure_clipboard_open()?;
+        Self::empty_clipboard()?;
+        let bitmap = image
+            .to_bitmap()
+            .map_err(|e| anyhow::anyhow!("Failed to convert image: {}", e))?;
+        let result = set_clipboard(formats::Bitmap, &bitmap.get_bytes().to_vec())
+            .map_err(|e| anyhow::anyhow!("Failed to write image: {}", e));
+        result
     }
 }
 
@@ -118,6 +137,34 @@ impl RsClipboard {
 impl RsClipboard {
     pub async fn wait_clipboard_change(&self) -> Result<()> {
         self.1.notified().await;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl RsClipboard {
+    fn ensure_clipboard_open() -> Result<()> {
+        unsafe {
+            if OpenClipboard(std::ptr::null_mut()) == 0 {
+                return Err(anyhow::anyhow!("Failed to open clipboard"));
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_clipboard_closed() -> Result<()> {
+        unsafe {
+            if CloseClipboard() == 0 {
+                return Err(anyhow::anyhow!("Failed to close clipboard"));
+            }
+        }
+        Ok(())
+    }
+
+    fn empty_clipboard() -> Result<()> {
+        if empty().is_err() {
+            return Err(anyhow::anyhow!("Failed to empty clipboard"));
+        }
         Ok(())
     }
 }

--- a/src/clipboard/clipboard.rs
+++ b/src/clipboard/clipboard.rs
@@ -4,6 +4,7 @@ use clipboard_rs::common::RustImage;
 use clipboard_rs::{Clipboard, ClipboardContext, ClipboardHandler, RustImageData};
 #[cfg(target_os = "windows")]
 use clipboard_win::empty;
+#[cfg(target_os = "windows")]
 use clipboard_win::{formats, set_clipboard};
 use log::debug;
 use std::sync::{Arc, Mutex};
@@ -13,7 +14,6 @@ use winapi::um::winuser::{CloseClipboard, OpenClipboard};
 
 use crate::config::CONFIG;
 use crate::message::Payload;
-use crate::config::CONFIG;
 use bytes::Bytes;
 
 pub struct RsClipboard(Arc<Mutex<ClipboardContext>>, Arc<Notify>);

--- a/src/clipboard_handler.rs
+++ b/src/clipboard_handler.rs
@@ -68,7 +68,7 @@ impl LocalClipboard {
             }
 
             let current = self.read().await?;
-            let current_hash = current.hash();
+            let current_hash = current.get_key();
 
             // 使用 RwLock 来安全地访问和修改 last_content_hash
             {

--- a/src/message.rs
+++ b/src/message.rs
@@ -52,17 +52,10 @@ impl ImagePayload {
     }
 
     pub fn is_similar(&self, other: &ImagePayload) -> bool {
-        let threshold = 0.95; // 95% 相似度阈值
-        let hash1 = self.content_hash();
-        let hash2 = other.content_hash();
-        let similarity = (hash1 as f64 - (hash1 ^ hash2) as f64) / hash1 as f64;
-        similarity >= threshold
-    }
-
-    pub fn is_likely_same(&self, other: &ImagePayload) -> bool {
-        self.width == other.width &&
-        self.height == other.height &&
-        (self.size as f64 - other.size as f64).abs() / (self.size as f64) < 0.1 // 允许 10% 的大小差异
+        // 尺寸一致且文件大小相差不超过 3%
+        self.width == other.width
+            && self.height == other.height
+            && (self.size as f64 - other.size as f64).abs() / (self.size as f64) <= 0.03
     }
 }
 
@@ -166,15 +159,13 @@ impl Payload {
     }
 
     /// 判断两个 Payload 是否相同
-    /// 
+    ///
     /// 文本消息只比较内容是否相同
     /// 图片消息只比较内容是否相似，不要求完全相同
     pub fn is_duplicate(&self, other: &Payload) -> bool {
         match (self, other) {
             (Payload::Text(t1), Payload::Text(t2)) => t1.content == t2.content,
-            (Payload::Image(i1), Payload::Image(i2)) => {
-                i1.is_likely_same(i2) && i1.is_similar(i2)
-            },
+            (Payload::Image(i1), Payload::Image(i2)) => i1.is_similar(i2),
             _ => false,
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,11 +1,10 @@
 use base64::Engine;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use hex;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use sha2::{Digest, Sha256};
 use std::fmt;
+use twox_hash::xxh3::hash64;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Payload {
@@ -130,16 +129,17 @@ impl Payload {
         }
     }
 
-    pub fn hash(&self) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(self.get_content());
-        hex::encode(hasher.finalize())
+    /// 获取 Payload 的唯一标识符
+    pub fn get_key(&self) -> String {
+        let content = self.get_content();
+        let hash = hash64(content);
+        format!("{:016x}", hash)
     }
 
     pub fn eq(&self, other: &Payload) -> bool {
         // TODO: 使用更高效的方式比较两个 Payload 是否相等
         //  比如对于图片类型，比较图片的大小、格式、尺寸等
-        self.hash() == other.hash()
+        self.get_key() == other.get_key()
     }
 
     pub fn to_json(&self) -> String {

--- a/src/message.rs
+++ b/src/message.rs
@@ -133,15 +133,13 @@ impl Payload {
     pub fn get_key(&self) -> String {
         match self {
             Payload::Text(p) => {
-                // 设备 ID + 文本 hash
-                let content = format!("{}_{}", p.device_id, hash64(p.content.as_ref()));
-                format!("{:016x}", hash64(content.as_bytes()))
+                format!("{:016x}", hash64(p.content.as_ref()))
             }
             Payload::Image(p) => {
-                // 设备 ID + 图片尺寸 + 图片格式 + 图片大小
+                // 图片尺寸 + 图片格式 + 图片大小
                 let content = format!(
-                    "{}_{}x{}_{}_{}",
-                    p.device_id, p.width, p.height, p.format, p.size
+                    "{}x{}_{}_{}",
+                    p.width, p.height, p.format, p.size
                 );
                 let hash = hash64(content.as_bytes());
                 format!("{:016x}", hash)

--- a/src/network/webdav.rs
+++ b/src/network/webdav.rs
@@ -76,7 +76,7 @@ impl WebDAVClient {
     ///
     /// Returns a Result containing the path of the uploaded file.
     pub async fn upload(&self, dir: String, payload: Payload) -> Result<String> {
-        let filename = format!("{}_{}.bin", payload.get_device_id(), payload.hash());
+        let filename = format!("{}_{}.bin", payload.get_device_id(), payload.get_key());
         let path: String;
         if dir == "/" {
             path = format!("/{}", filename);

--- a/src/uni_clipboard.rs
+++ b/src/uni_clipboard.rs
@@ -82,6 +82,10 @@ impl UniClipboard {
                         .unwrap_or(String::from(""))
                         == payload.get_key()
                     {
+                        info!(
+                            "Skip push to remote: {}, because it's the same as the last one",
+                            payload
+                        );
                         continue;
                     }
 
@@ -107,11 +111,11 @@ impl UniClipboard {
             while *is_running.read().await {
                 match remote_sync.pull(Some(Duration::from_secs(10))).await {
                     Ok(content) => {
+                        info!("Set local clipboard: {}", content);
                         let content_hash = content.get_key();
                         if let Err(e) = clipboard.set_clipboard_content(content).await {
                             error!("Failed to set clipboard content: {:?}", e);
                         }
-                        info!("Set local clipboard: {}", content_hash.clone());
                         *last_content_hash.write().await = Some(content_hash);
                     }
                     Err(e) => {

--- a/src/uni_clipboard.rs
+++ b/src/uni_clipboard.rs
@@ -80,7 +80,7 @@ impl UniClipboard {
                         .await
                         .clone()
                         .unwrap_or(String::from(""))
-                        == payload.hash()
+                        == payload.get_key()
                     {
                         continue;
                     }
@@ -107,7 +107,7 @@ impl UniClipboard {
             while *is_running.read().await {
                 match remote_sync.pull(Some(Duration::from_secs(10))).await {
                     Ok(content) => {
-                        let content_hash = content.hash();
+                        let content_hash = content.get_key();
                         if let Err(e) = clipboard.set_clipboard_content(content).await {
                             error!("Failed to set clipboard content: {:?}", e);
                         }
@@ -265,6 +265,10 @@ impl UniClipboardBuilder {
         let remote_sync_manager = RemoteSyncManager::new();
         remote_sync_manager.set_sync_handler(remote_sync).await;
 
-        Ok(UniClipboard::new(clipboard, remote_sync_manager, self.key_mouse_monitor))
+        Ok(UniClipboard::new(
+            clipboard,
+            remote_sync_manager,
+            self.key_mouse_monitor,
+        ))
     }
 }

--- a/tests/message_tests.rs
+++ b/tests/message_tests.rs
@@ -71,8 +71,8 @@ fn test_payload_hash() {
         Utc::now(),
     );
 
-    assert_eq!(payload1.hash(), payload2.hash());
-    assert_ne!(payload1.hash(), payload3.hash());
+    assert_eq!(payload1.get_key(), payload2.get_key());
+    assert_ne!(payload1.get_key(), payload3.get_key());
 }
 
 #[test]


### PR DESCRIPTION
This pull request introduces several important changes to enhance the clipboard functionality, improve payload handling, and refactor the codebase for better efficiency and maintainability. The key changes include adding Windows-specific clipboard handling, switching from SHA256 to `twox-hash` for hashing, and updating the payload comparison logic.

### Clipboard Handling Enhancements:
* [`src/clipboard/clipboard.rs`](diffhunk://#diff-37ae9297b365149bb769ee161e8f225fe0762d48b1757beeaaeef8633b1b712aR5-R16): Added Windows-specific clipboard handling functions, including `ensure_clipboard_open`, `ensure_clipboard_closed`, and `empty_clipboard`. These functions are used in the new `write_image` method for Windows. [[1]](diffhunk://#diff-37ae9297b365149bb769ee161e8f225fe0762d48b1757beeaaeef8633b1b712aR5-R16) [[2]](diffhunk://#diff-37ae9297b365149bb769ee161e8f225fe0762d48b1757beeaaeef8633b1b712aR68) [[3]](diffhunk://#diff-37ae9297b365149bb769ee161e8f225fe0762d48b1757beeaaeef8633b1b712aR78-R89) [[4]](diffhunk://#diff-37ae9297b365149bb769ee161e8f225fe0762d48b1757beeaaeef8633b1b712aR144-R171)

### Payload Handling Improvements:
* [`src/message.rs`](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L4-R7): Replaced SHA256 with `twox-hash` for generating payload keys. Added methods to `ImagePayload` for computing content hash and checking similarity. Updated `Payload` to use these methods for key generation and comparison. [[1]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L4-R7) [[2]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704R48-R61) [[3]](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704L133-R214)
* [`src/uni_clipboard.rs`](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3L23-R23): Refactored to store the last content payload instead of its hash, and updated the logic to use the new `is_duplicate` method for comparison. [[1]](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3L23-R23) [[2]](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3L38-R38) [[3]](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3L73-R84) [[4]](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3L104-R112)

### Miscellaneous Changes:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R64): Added `twox-hash` dependency.
* [`src/clipboard_handler.rs`](diffhunk://#diff-acd5b04632c670c90f605462374d4a53bc602adb7c5b8ce79625c854e781cb16L71-R71): Updated method to use `get_key` instead of `hash`.
* [`src/network/webdav.rs`](diffhunk://#diff-b7a1d9a71383383c679df2c1bd69e25bb36445f66840d83b85fb0d5838c51b95L79-R79): Updated filename generation to use `get_key` instead of `hash`.
* [`src/remote_sync/websocket_handler.rs`](diffhunk://#diff-ba7366d8a601b44566c439f60e21acc6ae77bdfdf061d85eb2074e0212fbf5cfR94): Added logging for pull results. [[1]](diffhunk://#diff-ba7366d8a601b44566c439f60e21acc6ae77bdfdf061d85eb2074e0212fbf5cfR94) [[2]](diffhunk://#diff-ba7366d8a601b44566c439f60e21acc6ae77bdfdf061d85eb2074e0212fbf5cfL108-L117)
* [`tests/message_tests.rs`](diffhunk://#diff-7c53e3a117b0be848f62446b54dc5de6cb7c57ab4b5cc0a3fc4f550162de80f8L74-R75): Updated tests to use `get_key` instead of `hash`.