### PR TITLE
refactor: 日志时间精确到毫秒以及展示文件及行号

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,26 +752,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.2"
+name = "env_logger"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
+ "termcolor",
 ]
 
 [[package]]
@@ -1112,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,7 +1583,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -2747,6 +2754,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,6 +3289,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.1"
 edition = "2021"
 
 [profile.release]
-panic = "abort" # Strip expensive panic clean-up logic
+panic = "abort"   # Strip expensive panic clean-up logic
 codegen-units = 1 # Compile crates one after another so the compiler can optimize better
-lto = true # Enables link to optimizations
-opt-level = "z" # Optimize for binary size
-strip = true # Remove debug symbols
+lto = true        # Enables link to optimizations
+opt-level = "z"   # Optimize for binary size
+strip = true      # Remove debug symbols
 
 [features]
 clipboard_tests = []
@@ -31,7 +31,7 @@ anyhow = "1.0.89"
 
 # 日志
 log = "0.4"
-env_logger = "0.11.5"
+env_logger = { version = "0.10", features = ["color"] }
 
 # 命令行参数解析
 clap = { version = "4.3", features = ["derive"] }
@@ -65,7 +65,12 @@ twox-hash = "1.6.3"
 
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.4.0" }
-winapi = { version = "0.3.9", features = ["winuser", "basetsd", "minwindef", "winbase"] }
+winapi = { version = "0.3.9", features = [
+    "winuser",
+    "basetsd",
+    "minwindef",
+    "winbase",
+] }
 
 [dependencies.uuid]
 version = "1.10.0"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,36 @@
+use chrono::Local;
+use env_logger::{Builder, Env};
+use log::LevelFilter;
+use std::io::Write;
+
+pub fn init() {
+    Builder::from_env(Env::default().default_filter_or("debug"))
+        .format(|buf, record| {
+            let mut style = buf.style();
+            let level_style = match record.level() {
+                log::Level::Error => style.set_color(env_logger::fmt::Color::Red).set_bold(true),
+                log::Level::Warn => style.set_color(env_logger::fmt::Color::Yellow),
+                log::Level::Info => style.set_color(env_logger::fmt::Color::Green),
+                log::Level::Debug => style.set_color(env_logger::fmt::Color::Blue),
+                log::Level::Trace => style.set_color(env_logger::fmt::Color::Cyan),
+            };
+
+            let file = record.file().unwrap_or("unknown");
+            let line = record
+                .line()
+                .map_or_else(|| "".to_string(), |l| l.to_string());
+
+            writeln!(
+                buf,
+                "{} {} [{}:{}] [{}] {}",
+                Local::now().format("%Y-%m-%d %H:%M:%S%.3f"),
+                level_style.value(record.level()),
+                file,
+                line,
+                record.target(),
+                record.args()
+            )
+        })
+        .filter(None, LevelFilter::Info)
+        .init();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod device;
 mod encrypt;
 mod file_metadata;
 mod key_mouse_monitor;
+mod logger;
 mod message;
 mod network;
 mod remote_sync;
@@ -22,8 +23,6 @@ use crate::cli::{interactive_input, parse_args};
 use crate::clipboard_handler::LocalClipboard;
 use crate::config::Config;
 use anyhow::Result;
-use env_logger::Env;
-use network::WebDAVClient;
 
 // 新增函数用于显示标志
 fn display_banner() {
@@ -47,7 +46,8 @@ fn display_banner() {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(Env::default().default_filter_or("debug")).init();
+    logger::init();
+
     display_banner();
 
     let args = parse_args();

--- a/src/uni_clipboard.rs
+++ b/src/uni_clipboard.rs
@@ -10,9 +10,9 @@ use tokio::time::sleep;
 use crate::clipboard_handler::LocalClipboard;
 use crate::key_mouse_monitor::KeyMouseMonitor;
 use crate::message::Payload;
+use crate::network::WebDAVClient;
 use crate::remote_sync::manager::RemoteSyncManager;
 use crate::remote_sync::{RemoteClipboardSync, WebDavSync, WebSocketSync};
-use crate::WebDAVClient;
 
 pub struct UniClipboard {
     clipboard: Arc<LocalClipboard>,
@@ -78,7 +78,10 @@ impl UniClipboard {
                     let last_content = last_content.read().await;
                     if let Some(last_payload) = last_content.as_ref() {
                         if last_payload.is_duplicate(&payload) {
-                            info!("Skip push to remote: {}, because it's the same as the last one", payload);
+                            info!(
+                                "Skip push to remote: {}, because it's the same as the last one",
+                                payload
+                            );
                             continue;
                         }
                     }


### PR DESCRIPTION
This pull request includes several changes to improve logging functionality and refactor dependencies in the `Cargo.toml` file. The most important changes involve updating the `env_logger` configuration, adding a new `logger` module, and refactoring the `main.rs` and `uni_clipboard.rs` files to use the new logger.

### Logging Improvements:

* [`src/logger.rs`](diffhunk://#diff-6658812715089c8241f20814aaf257dbd94a5448e01cf0010a0a2da54406f844R1-R36): Added a new logger initialization function using `env_logger` with custom formatting and color-coded log levels. (`[src/logger.rsR1-R36](diffhunk://#diff-6658812715089c8241f20814aaf257dbd94a5448e01cf0010a0a2da54406f844R1-R36)`)
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL50-R50): Replaced the old `env_logger` initialization with the new `logger::init()` function. (`[src/main.rsL50-R50](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL50-R50)`)
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR9): Added the `logger` module import. (`[src/main.rsR9](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR9)`)

### Dependency Updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L34-R34): Updated `env_logger` to version `0.10` with the `color` feature enabled. (`[Cargo.tomlL34-R34](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L34-R34)`)
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L68-R73): Reformatted the `winapi` dependency for better readability. (`[Cargo.tomlL68-R73](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L68-R73)`)

### Code Refactoring:

* [`src/uni_clipboard.rs`](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3R13-L15): Moved the `WebDAVClient` import to a more appropriate location and reformatted a logging statement for better readability. (`[[1]](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3R13-L15)`, `[[2]](diffhunk://#diff-270a920f1b38c0168b9c4a7173702606ab29c3232081fa2d3c46064f5b8f42b3L81-R84)`)
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL25-L26): Removed unused imports related to the old `env_logger` setup. (`[src/main.rsL25-L26](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL25-L26)`)