### PR TITLE
默认日志等级为 debug

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,6 +1,5 @@
 use chrono::Local;
 use env_logger::{Builder, Env};
-use log::LevelFilter;
 use std::io::Write;
 
 pub fn init() {
@@ -31,6 +30,5 @@ pub fn init() {
                 record.args()
             )
         })
-        .filter(None, LevelFilter::Info)
         .init();
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/logger.rs` file. The change removes the `LevelFilter` import and its usage in the `init` function.

Changes to logging configuration:

* [`src/logger.rs`](diffhunk://#diff-6658812715089c8241f20814aaf257dbd94a5448e01cf0010a0a2da54406f844L3): Removed the `LevelFilter` import and its usage in the `init` function, simplifying the logging setup. [[1]](diffhunk://#diff-6658812715089c8241f20814aaf257dbd94a5448e01cf0010a0a2da54406f844L3) [[2]](diffhunk://#diff-6658812715089c8241f20814aaf257dbd94a5448e01cf0010a0a2da54406f844L34)