### PR TITLE
fix: 尝试修复在 windows 上，图片数据无法写入到剪切板的问题

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -90,6 +90,9 @@ impl DeviceManager {
                 new_devices.push(device.clone());
             }
         }
+        for device in &new_devices {
+            self.add(device.clone());
+        }
         new_devices
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -114,6 +114,10 @@ impl DeviceManager {
         self.devices.values().collect()
     }
 
+    pub fn clear(&mut self) {
+        self.devices.clear();
+    }
+
     /// 通过 ip 和 port 获取设备
     pub fn get_device_by_ip_and_port(&self, ip: &str, port: u16) -> Option<&Device> {
         self.devices.values().find(|device| {

--- a/src/web/handlers/websocket_message.rs
+++ b/src/web/handlers/websocket_message.rs
@@ -542,9 +542,12 @@ mod tests {
 
         let device_manager = get_device_manager();
         let guard = device_manager.try_lock();
-        if let Ok(guard) = guard {
+        if let Ok(mut guard) = guard {
             let devices = guard.get_all_devices();
-            assert_eq!(devices.len(), 3);
+            let len = devices.len();
+            assert_eq!(len, 3);
+            guard.clear();
+            assert_eq!(guard.get_all_devices().len(), 0);
         } else {
             assert!(false);
         }


### PR DESCRIPTION
This pull request includes significant changes to the `src/clipboard/clipboard.rs` and `src/web/handlers/websocket_message.rs` files. The most important changes involve simplifying image conversion logic and improving error handling in WebSocket message broadcasting.

### Simplification of Image Conversion Logic:
* [`src/clipboard/clipboard.rs`](diffhunk://#diff-37ae9297b365149bb769ee161e8f225fe0762d48b1757beeaaeef8633b1b712aL91-R97): Removed the `parallel_convert_image` and `convert_image_simple` methods, replacing them with a simpler approach using `image.to_png().unwrap()` for PNG conversion.

### Improved Error Handling in WebSocket Broadcasting:
* [`src/web/handlers/websocket_message.rs`](diffhunk://#diff-8bb7afadf29d64e945c200eeceef66b2c1e39fdac059feb4742fd01edb28cde6L211-R235): Modified the `broadcast_to_outgoing` method to use a read lock instead of a write lock, added error collection for failed message sends, and improved the error reporting mechanism.
* [`src/web/handlers/websocket_message.rs`](diffhunk://#diff-8bb7afadf29d64e945c200eeceef66b2c1e39fdac059feb4742fd01edb28cde6L256-R281): Updated the `broadcast_message` method to collect errors from both outgoing and incoming message broadcasts, and return a combined error if any occur.