### PR TITLE
Fix/macos arm64 sqlite build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,9 +159,7 @@ jobs:
           cat artifacts/version/version.txt
           echo "RELEASE_VERSION=$(cat artifacts/version/version.txt)" >> $GITHUB_ENV
 
-      # Linux & Windows
       - name: Install rust toolchain
-        if: ${{ !contains(matrix.platform.target, 'apple') }}
         uses: actions-rs/toolchain@v1
         with:
           # We setup Rust toolchain and the desired target
@@ -171,41 +169,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           components: rustfmt, clippy
 
-      # Linux & Windows 构建，缓存依赖
       - name: Cache dependencies for ${{ matrix.platform.name }}
-        if: ${{ !contains(matrix.platform.target, 'apple') }}
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Build ${{ matrix.platform.name }} binary
-        if: ${{ !contains(matrix.platform.target, 'apple') }}
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_BUILD_JOBS: 4
-        # We use cross-rs if not running on x86_64 architecture on Linux
-        with:
-          command: build
-          use-cross: ${{ !contains(matrix.platform.target, 'x86_64') }}
-          args: ${{ env.BUILD_ARGS }} --target ${{ matrix.platform.target }}
-
-      # Mac OS
-      - name: Login to DockerHub
-        if: contains(matrix.platform.target, 'apple')
-        # We log on DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKER_LOGIN }}
-          password: ${{ env.DOCKER_TOKEN }}
-
-      # 缓存构建，用于 Macos
-      - name: Cache Cargo and build directories
-        if: contains(matrix.platform.target, 'apple')
         uses: actions/cache@v3
         with:
           path: |
@@ -214,17 +178,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.platform.target }}-cargo-
 
-      # 构建 Macos 二进制文件
       - name: Build ${{ matrix.platform.name }} binary
-        if: contains(matrix.platform.target, 'apple')
-        # We use a dedicated Rust image containing required Apple libraries to cross-compile on multiple archs
-        run: |
-          docker run --rm \
-            --volume "${PWD}":/root/src \
-            --volume "${PWD}/target":/root/src/target \
-            --workdir /root/src \
-            joseluisq/rust-linux-darwin-builder:${{ env.RUST_VERSION }} \
-            sh -c "CC=o64-clang CXX=o64-clang++ RUSTFLAGS='-C linker=o64-clang' cargo build ${{ env.BUILD_ARGS }} --target ${{ matrix.platform.target }}"
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_BUILD_JOBS: 4
+        with:
+          command: build
+          args: ${{ env.BUILD_ARGS }} --target ${{ matrix.platform.target }}
 
       - name: Store artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,8 +132,10 @@ jobs:
           # Mac OS
           - name: MacOS x86_64
             target: x86_64-apple-darwin
+            os: macos-14-large
           - name: MacOS aarch64
             target: aarch64-apple-darwin
+            os: macos-14
 
           # Windows
           - name: Windows x86_64
@@ -201,6 +203,7 @@ jobs:
           username: ${{ env.DOCKER_LOGIN }}
           password: ${{ env.DOCKER_TOKEN }}
 
+      # 缓存构建，用于 Macos
       - name: Cache Cargo and build directories
         if: contains(matrix.platform.target, 'apple')
         uses: actions/cache@v3
@@ -211,6 +214,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.platform.target }}-cargo-
 
+      # 构建 Macos 二进制文件
       - name: Build ${{ matrix.platform.name }} binary
         if: contains(matrix.platform.target, 'apple')
         # We use a dedicated Rust image containing required Apple libraries to cross-compile on multiple archs


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflow for releases in the `.github/workflows/release.yaml` file. The changes focus on improving the build process for different platforms (MacOS, Windows, and Linux) and simplifying the workflow by removing redundant steps.

Improvements to the build process:

* Updated the MacOS build targets to use `macos-14-large` and `macos-14` for x86_64 and aarch64 respectively.
* Removed the conditional checks for non-Apple targets in the Linux and Windows build steps, streamlining the build process. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL160-L162) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL172-L224)

Simplification of the workflow:

* Consolidated the caching strategy for dependencies across all platforms by removing platform-specific conditions and using `actions/cache@v3` for all targets.
* Removed redundant Docker login and build steps for MacOS, as these steps are now unified across all platforms.