### PR TITLE
ci: improve caching strategy for faster builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,16 +19,28 @@ jobs:
       RUST_TEST_THREADS: 1
     steps:
     - uses: actions/checkout@v4
+
     - name: Install rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
         toolchain: stable
+
+    - name: Cache dependencies for ${{ matrix.platform.name }}
+      uses: actions/cache@v3
+      with:
+        path: |
+          target
+        key: ${{ runner.os }}-${{ matrix.platform.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ matrix.platform.target }}-cargo-
+
     - name: Install dependencies (Ubuntu)
       if: matrix.platform == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt-get install -y pkg-config libssl-dev libxdo-dev
+
     - name: Run tests
       run: make ci
 


### PR DESCRIPTION
This pull request includes an update to the CI workflow configuration in the `.github/workflows/ci.yaml` file to improve the efficiency of the CI process by caching dependencies.

Improvements to CI workflow:

* Added a step to cache dependencies using `actions/cache@v3` to reduce build times by reusing previously downloaded dependencies.